### PR TITLE
Address Backend Defensiveness for Template Arguments

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+#
+#    Copyright 2018-2019 Google LLC All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the script for Travis CI hosted, distributed continuous 
+#      integration 'before_install' trigger of the 'install' step.
+#

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -21,3 +21,42 @@
 #      This file is the script for Travis CI hosted, distributed continuous 
 #      integration 'before_install' trigger of the 'install' step.
 #
+
+#
+# installdeps <dependency tag>
+#
+# Abstraction for handling common dependency fulfillment across
+# different, but related, test targets.
+#
+installdeps()
+{
+    case "${1}" in
+
+        protoc-deps)
+            sudo contrib/download_protoc.sh
+
+            ;;
+
+    esac
+}
+
+# Package build machine OS-specific configuration and setup
+
+case "${TRAVIS_OS_NAME}" in
+
+    linux)
+        installdeps "protoc-deps"
+
+        sudo apt-get update
+        sudo apt-get install python2.7 python-pip python-virtualenv
+
+        ;;
+
+    osx)
+        installdeps "protoc-deps"
+
+        easy_install pip virtualenv
+
+        ;;
+
+esac

--- a/Makefile.am
+++ b/Makefile.am
@@ -253,8 +253,12 @@ dist srcdist: | announce-version
 srcdist: dist
 
 $(RESULTSDIR)/$(WDLC_CODEGENDIR)/%: codegen/% | $(RESULTSDIR)/$(WDLC_CODEGENDIR)
+	$(NL_V_AT)if [ ! -d "$(@D)" ]; then \
+	    $(_NL_PROGRESS) "MKDIR" "$(@D)"; \
+	    $(MKDIR_P) "$(@D)"; \
+	fi
 	$(NL_V_PROGRESS) "COPY" "$(@)"
-	$(NL_V_AT)install -D -m 0444 "$(<)" "$(@)"
+	$(NL_V_AT)$(INSTALL) -m 0444 "$(<)" "$(@)"
 
 .PHONY: $(PACKAGE)
 $(PACKAGE): all

--- a/Makefile.in
+++ b/Makefile.in
@@ -1011,8 +1011,12 @@ dist srcdist: | announce-version
 srcdist: dist
 
 $(RESULTSDIR)/$(WDLC_CODEGENDIR)/%: codegen/% | $(RESULTSDIR)/$(WDLC_CODEGENDIR)
+	$(NL_V_AT)if [ ! -d "$(@D)" ]; then \
+	    $(_NL_PROGRESS) "MKDIR" "$(@D)"; \
+	    $(MKDIR_P) "$(@D)"; \
+	fi
 	$(NL_V_PROGRESS) "COPY" "$(@)"
-	$(NL_V_AT)install -D -m 0444 "$(<)" "$(@)"
+	$(NL_V_AT)$(INSTALL) -m 0444 "$(<)" "$(@)"
 
 .PHONY: $(PACKAGE)
 $(PACKAGE): all

--- a/backend/lib/nwv/wdl_plugin.py
+++ b/backend/lib/nwv/wdl_plugin.py
@@ -69,6 +69,9 @@ def codegen(request, response):
   codegen_reference_mode = ('codegen_reference_mode' in args and
                                 args['codegen_reference_mode'].lower() == 'true')
 
+  if args['templates'] is None or not args['templates']:
+    raise Exception('wdl_plugin: \'templates\' argument is empty')
+
   if isinstance(args['templates'], list):
     template_files = args['templates']
   else:

--- a/contrib/download_protoc.sh
+++ b/contrib/download_protoc.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+#
+#    Copyright (c) 2019 Google LLC. All Rights Reserved.
+#    Copyright (c) 2016-2018 Nest Labs Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+##
+#    @file
+#     	Script to help download a minimum-viable version of Google
+#       Protocol Buffers (protobuf) compiler, protoc.
+#
+
+dest_dir="/usr/local"
+
+function usage() {
+    local name=`basename ${0}`
+
+    if [ ${1} -ne 0 ]; then
+        echo "Try '${name} -h' for more information."
+    fi
+
+    if [ ${1} -ne 1 ]; then
+        echo "OpenWeave Weave Data Language (WDL) Compiler - Protoc Installation Script"
+        echo ""
+        echo "Options:"
+        echo ""
+        echo "  -h, --help         Print this help, then exit."
+        echo "  -f, --force        Over-ride the local installation of protoc regardless of version"
+        echo "  -d, --destdir DIR  Over-ride the destination directory (default: ${dest_dir})"
+    fi
+
+    exit ${1}
+}
+
+force_install=false
+
+# While there are command line options and arguments to parse, parse
+# and consume them.
+
+while [ "${#}" -gt 0 ]; do
+
+    case ${1} in
+
+        -h | --help)
+            usage 0
+            ;;
+
+        
+        -f | --force)
+            force_install=true
+            shift 1
+            ;;
+
+        -d | --destdir)
+            dest_dir="${2}"
+            shift 2
+            ;;
+
+        -*)
+            echo "Unknown or invalid option: '${1}'"
+            usage 1
+            ;;
+
+    esac
+
+done
+
+#
+# progress <ACTION> <target>
+#
+# Display to standard output the specified action (capitalized by
+# convention) and target arguments.
+#
+function progress() {
+    printf "  %-13s %s\n" "${1}" "${2}"
+}
+
+# If the destination directory doesn't exist, error out.
+if [ ! -d "${dest_dir}" ]; then
+    usage 1
+fi
+
+protoc_version_min="3.5.1"
+protoc_version_max="3.7.1"
+VERSION="3.7.1"
+
+if [ -f "${dest_dir}/bin/protoc" ]; then
+    protoc_version=`${dest_dir}/bin/protoc --version 2>&1 | sed -n -e 's/^.\{1,\}\([0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}\)$/\1/gp'`
+
+    protoc_at_least_major_minor_patch=`printf "${protoc_version_min}\n${protoc_version}\n" | sed 's/^ *//' | sort | sed "s/${protoc_version_min}/yes/ ; s/${protoc_version}/no/ ; 1q"`
+    protoc_at_most_major_minor_patch=`printf "${protoc_version}\n${protoc_version_max}\n" | sed 's/^ *//' | sort | sed "s/${protoc_version}/yes/ ; s/${protoc_version_max}/no/ ; 1q"`
+
+    if [[ "${protoc_at_most_major_minor_patch}" = "yes" && "${protoc_at_least_major_minor_patch}" = "yes" ]]; then
+        version_in_range=true
+    else
+        version_in_range=false
+    fi
+
+    if [ "${force_install}" = false ]; then
+        if [ "${version_in_range}" = true ]; then
+            echo "Existing installation of version ${protoc_version} already meets the min and max requirements - nothing else to be done!"
+            exit 0
+        else
+           echo "Error: Existing installation present but no --force option provided, so exiting without doing anything"
+           exit 1
+        fi
+   else
+       echo "**WARNING** Existing installation found - over-riding..."
+
+       # Remove the existing installation
+       rm ${dest_dir}/bin/protoc
+       rm -rf ${dest_dir}/include/google/protobuf
+   fi 
+fi
+
+# Figure out the platform we're running on, and deduce the appropriate platform prefix for the download image.
+if [[ "$(uname -s)" == "Linux" ]]; then
+    platform="linux-x86_64"
+elif [[ "$(uname -s)" == "Darwin" ]]; then
+    platform="osx-x86_64"
+else
+    echo "Error: Unknown OS: Please run on a Linux or Darwin system, or manually download the relevant image"
+    echo "from https://github.com/google/protobuf/releases/tag/v${VERSION}"
+    exit 1
+fi
+
+filename="protoc-${VERSION}-${platform}.zip"
+github_url="https://github.com/google/protobuf/releases/download/v${VERSION}/${filename}"
+
+echo ${github_url}
+
+if ! (curl -L --fail "${github_url}" > "${dest_dir}/temp.zip"); then
+    >&2 echo "Error: Unable to reach github, cannot download protoc"
+    exit 1
+fi
+
+unzip -o -q "${dest_dir}/temp.zip" -d "${dest_dir}"
+rm "${dest_dir}/temp.zip"


### PR DESCRIPTION
Absent this check, the user is left with an inscrutable backtrace that leaves little insight on what went wrong or what the user should do about it if the templates argument is empty, such as might happen when the user invokes the compiler on an empty templates directory.