### PR TITLE
Emit make-compatible dependency file

### DIFF
--- a/wdlc.sh.in
+++ b/wdlc.sh.in
@@ -88,8 +88,12 @@ function usage() {
         echo "                                       schema that can be used in place of "
         echo "                                       schema in a future invocation, or used "
         echo "                                       for version validation using the"
-        echo "  --output-dependency-file FILE        Emit dependency file information that is compatible"
-        echo "                                       with make for the given input to FILE"
+        echo "  -MF FILE                             Emit dependency file information that is compatible"
+        echo "                                       with make for the given input to FILE (requires -MT option)"
+        echo "  -MT TARGET                           When using the -MF option, specifies the target to emitted"
+        echo "                                       in the dependency file"
+        echo "  -MP                                  Adds a phony target for each dependency other than that specified"
+        echo "                                       by -MT."
         echo "                                       --previous-intermediate-in option."
         echo "  -o, --output DIR                     Generate code to the output directory"
         echo "  -q, --quiet                          Work silently; do not display diagnostic"
@@ -270,6 +274,35 @@ function remove_proto_descriptor_set() {
 }
 
 #
+# fixup_dependency_file <file-name> <target> <emit-phony-target>
+#
+# Fixes up the dependency file emitted by protoc to be compliant with
+# make
+#
+function fixup_dependency_file() {
+    local file_path="${1}"
+    local target="${2}"
+    local emit_phony="${3}"
+
+    # Setup a scratch file with the target
+    echo -e "${target}: \\" > "${file_path}".tmp
+
+    # Append the dependency set to the tmp file
+    cat "${file_path}" >> "${file_path}".tmp
+
+    if [ ${emit_phony} = true ]; then
+        echo -e "\n" >> "${file_path}".tmp
+
+        # Emit the entire dependency set again, and terminate it with a colon
+        cat "${file_path}" >> "${file_path}".tmp
+        echo -e ':' >> "${file_path}".tmp
+    fi
+
+    # Move the tmp file back to the requested output file
+    mv "${file_path}".tmp "${file_path}"
+}
+
+#
 # protoc_generate_code <template directory> <output directory>
 #
 # Maybe drive, if not dry-running, protoc to perform code generation.
@@ -373,6 +406,8 @@ template_dir=""
 template_arg=""
 verbose=0
 dependency_file_path=""
+dependency_file_target=""
+emit_phony_target=false
 
 while [ "${#}" -gt 0 ]; do
 
@@ -436,9 +471,19 @@ while [ "${#}" -gt 0 ]; do
             shift 2
             ;;
 
-        --output-dependency-file)
+        -MF)
             dependency_file_path=${2}
             shift 2
+            ;;
+
+        -MT)
+            dependency_file_target=${2}
+            shift 2
+            ;;
+
+        -MP)
+            emit_phony_target=true
+            shift 1
             ;;
 
         -q | --quiet)
@@ -632,6 +677,11 @@ if [ ${should_dry_run} -eq 0 ]; then
     check_required_executable GWVC gwvc
 fi
 
+if [ -n "${dependency_file_path}" ] && [ ! -n "${dependency_file_target}" ]; then
+    echo "A target must be specified through the -MT option!"
+    usage 1
+fi
+
 # Whether we are checking / validating the schema corpus or running
 # code generation, the coherency and correctness of the schema corpus
 # must be verified first.
@@ -644,6 +694,11 @@ if [ ${mode} = "check"  ] || [ ${mode} = "codegen" ]; then
 
     if [ "${input_format}" == "source" ]; then
         protoc_generate_proto_descriptor_set "${current_proto_descriptor_set_path}" "${dependency_file_path}"
+    fi
+
+    # Fix-up the dependency file to be compliant with what make expects
+    if [ -n "${dependency_file_path}" ]; then
+        fixup_dependency_file "${dependency_file_path}" "${dependency_file_target}" "${emit_phony_target}"
     fi
 
     # Drive, if not dry-running, the gwvc back-end to generate

--- a/wdlc.sh.in
+++ b/wdlc.sh.in
@@ -88,6 +88,8 @@ function usage() {
         echo "                                       schema that can be used in place of "
         echo "                                       schema in a future invocation, or used "
         echo "                                       for version validation using the"
+        echo "  --output-dependency-file FILE        Emit dependency file information that is compatible"
+        echo "                                       with make for the given input to FILE"
         echo "                                       --previous-intermediate-in option."
         echo "  -o, --output DIR                     Generate code to the output directory"
         echo "  -q, --quiet                          Work silently; do not display diagnostic"
@@ -233,11 +235,19 @@ function gwvc_compare_schema_versions() {
 #
 function protoc_generate_proto_descriptor_set() {
     local descriptor_set_path="${1}"
+    local dependency_file_path="${2}"
+    local dependency_option=""
+
+    if [ -n "${2}" ] ; then
+        dependency_option="--dependency_out ${2}"
+    fi
+
     local command="${PROTOC} \
         --include_source_info \
         --include_imports \
         ${protoc_search_path_options} \
         --descriptor_set_out=${descriptor_set_path} \
+        ${dependency_option} \
         ${input_paths}"
 
     # Generate, if not dry-running, the protobuf file set descriptor
@@ -362,6 +372,7 @@ should_dry_run=0
 template_dir=""
 template_arg=""
 verbose=0
+dependency_file_path=""
 
 while [ "${#}" -gt 0 ]; do
 
@@ -422,6 +433,11 @@ while [ "${#}" -gt 0 ]; do
 
         --output-intermediate)
             intermediate_output_path=${2}
+            shift 2
+            ;;
+
+        --output-dependency-file)
+            dependency_file_path=${2}
             shift 2
             ;;
 
@@ -627,7 +643,7 @@ if [ ${mode} = "check"  ] || [ ${mode} = "codegen" ]; then
     # in the specified protobuf file set descriptor binary.
 
     if [ "${input_format}" == "source" ]; then
-        protoc_generate_proto_descriptor_set "${current_proto_descriptor_set_path}"
+        protoc_generate_proto_descriptor_set "${current_proto_descriptor_set_path}" "${dependency_file_path}"
     fi
 
     # Drive, if not dry-running, the gwvc back-end to generate


### PR DESCRIPTION
Adds a `--dependency-file FILE` option to WDLC to permit emission of a make-compatible dependency file a given Proto input.
