### PR TITLE
Shuffle include path ordering

### DIFF
--- a/wdlc.sh.in
+++ b/wdlc.sh.in
@@ -598,8 +598,6 @@ if [ -d "${intermediate_output_path}" ]; then
     usage 1 "${wdlc_datadir}"
 fi
 
-protoc_search_path_options="--proto_path ${wdlc_includedir}"
-
 # The template argument for code generation is either a short-cut to a
 # wdlc-internal directory or an absolute or relative path to an
 # external template directory. Attempt to form the former and
@@ -637,6 +635,10 @@ if [ ${#protoc_search_paths[@]} -gt 0 ]; then
         protoc_search_path_options+=" --proto_path ${protoc_search_path}"
     done
 fi
+
+# We append the compiler-specific include path after to allow for the user to specify paths
+# that can over-ride the content provided by the installed compiler (e.g test traits)
+protoc_search_path_options+=" --proto_path ${wdlc_includedir}"
 
 # If the input points to a directory, convert it to specify the set of proto files in them instead.
 if [ -d "${input_paths}" ]; then


### PR DESCRIPTION
This re-orders the include paths provided to protoc during a schema
compile, to have the user-provided paths be passed in first before the
WDLC compiler installed include path. This allows the user to pass in
paths to files that may over-ride the installed set that come with the
compiler (e.g test traits).