### PR TITLE
Cleanup/remove field from test trait

### DIFF
--- a/codegen/weave-device-cpp/reference/nest/test/trait/TestCTrait.cpp
+++ b/codegen/weave-device-cpp/reference/nest/test/trait/TestCTrait.cpp
@@ -46,7 +46,6 @@ const TraitSchemaEngine::PropertyInfo PropertyMap[] = {
     { kPropertyHandle_TcC, 1 }, // sc_a
     { kPropertyHandle_TcC, 2 }, // sc_b
     { kPropertyHandle_Root, 4 }, // tc_d
-    { kPropertyHandle_Root, 5 }, // tc_e
 };
 
 //

--- a/codegen/weave-device-cpp/reference/nest/test/trait/TestCTrait.h
+++ b/codegen/weave-device-cpp/reference/nest/test/trait/TestCTrait.h
@@ -30,7 +30,6 @@
 #include <Weave/Profiles/data-management/DataManagement.h>
 #include <Weave/Support/SerializationUtils.h>
 
-#include <nest/test/trait/TestCommonVersioned.h>
 
 
 namespace Schema {
@@ -87,14 +86,9 @@ enum {
     kPropertyHandle_TcD = 7,
 
     //
-    //  tc_e                                nest.test.trait.TestCommonVersioned.CommonEnumE int               NO              NO
-    //
-    kPropertyHandle_TcE = 8,
-
-    //
     // Enum for last handle
     //
-    kLastSchemaHandle = 8,
+    kLastSchemaHandle = 7,
 };
 
 //

--- a/codegen/weave-device-cpp/reference/nest/test/trait/TestDTrait.cpp
+++ b/codegen/weave-device-cpp/reference/nest/test/trait/TestDTrait.cpp
@@ -46,7 +46,6 @@ const TraitSchemaEngine::PropertyInfo PropertyMap[] = {
     { kPropertyHandle_TcC, 1 }, // sc_a
     { kPropertyHandle_TcC, 2 }, // sc_b
     { kPropertyHandle_Root, 4 }, // tc_d
-    { kPropertyHandle_Root, 5 }, // tc_e
     { kPropertyHandle_Root, 32 }, // td_d
     { kPropertyHandle_Root, 33 }, // td_e
     { kPropertyHandle_Root, 34 }, // td_f
@@ -68,7 +67,7 @@ const TraitSchemaEngine TraitSchema = {
         sizeof(PropertyMap) / sizeof(PropertyMap[0]),
         2,
 #if (TDM_EXTENSION_SUPPORT) || (TDM_VERSIONING_SUPPORT)
-        9,
+        8,
 #endif
         NULL,
         NULL,

--- a/codegen/weave-device-cpp/reference/nest/test/trait/TestDTrait.h
+++ b/codegen/weave-device-cpp/reference/nest/test/trait/TestDTrait.h
@@ -31,7 +31,6 @@
 #include <Weave/Support/SerializationUtils.h>
 
 #include <nest/test/trait/TestCTrait.h>
-#include <nest/test/trait/TestCommonVersioned.h>
 
 
 namespace Schema {
@@ -88,29 +87,24 @@ enum {
     kPropertyHandle_TcD = 7,
 
     //
-    //  tc_e                                nest.test.trait.TestCommonVersioned.CommonEnumE int               NO              NO
-    //
-    kPropertyHandle_TcE = 8,
-
-    //
     //  td_d                                string                               string            NO              NO
     //
-    kPropertyHandle_TdD = 9,
+    kPropertyHandle_TdD = 8,
 
     //
     //  td_e                                int32                                int32             NO              NO
     //
-    kPropertyHandle_TdE = 10,
+    kPropertyHandle_TdE = 9,
 
     //
     //  td_f                                bool                                 bool              NO              NO
     //
-    kPropertyHandle_TdF = 11,
+    kPropertyHandle_TdF = 10,
 
     //
     // Enum for last handle
     //
-    kLastSchemaHandle = 11,
+    kLastSchemaHandle = 10,
 };
 
 } // namespace TestDTrait

--- a/test/schema/nest/test/trait/test_c_trait.proto
+++ b/test/schema/nest/test/trait/test_c_trait.proto
@@ -25,13 +25,6 @@ message TestCTrait {
         id: 0xFE03,
         version: 2,
         stability: ALPHA,
-        version_map: [
-          {
-             parent_version: 2, dependent_version_list: [
-               {name: "nest.test.trait.TestCommonVersioned", version: 2}
-             ]
-          }
-        ]
     };
 
     message StructC {
@@ -74,5 +67,4 @@ message TestCTrait {
     EnumC tc_b = 2;
     StructC tc_c = 3;
     uint32 tc_d = 4 [(wdl.prop) = {compatibility: {min_version: 2}}];
-    TestCommonVersioned.CommonEnumE tc_e = 5;
 }

--- a/test/schema/nest/test/trait/test_d_trait.proto
+++ b/test/schema/nest/test/trait/test_d_trait.proto
@@ -28,7 +28,6 @@ message TestDTrait {
         version_map: [
           {
              parent_version: 2, dependent_version_list: [
-               {name: "nest.test.trait.TestCommonVersioned", version: 2},
                {name: "nest.test.trait.TestCTrait", version: 2}
              ]
           }
@@ -51,7 +50,6 @@ message TestDTrait {
     TestCTrait.EnumC tc_b = 2;
     TestCTrait.StructC tc_c = 3;
     uint32 tc_d = 4 [(wdl.prop) = {compatibility: {min_version: 2}}];
-    TestCommonVersioned.CommonEnumE tc_e = 5;
 
     // ---- Extended Trait ---- //
     string td_d = 32;


### PR DESCRIPTION
Following a code review, we could not definitively answer why this
field was added.  Its presence, complicates maintenance at this point
in time: generated code for those traits now breaks tests in TestTDM
in openweave-core.  The expedient workaround is to remove the field
for now; we can re-add it with a suitable test case in openweave-core.

Reference files have been updated to reflect the modified test traits.