### PR TITLE
Fix Instance ID Validator

### DIFF
--- a/backend/lib/nwv/validators/trait_instance_id_validator.py
+++ b/backend/lib/nwv/validators/trait_instance_id_validator.py
@@ -44,11 +44,4 @@ class TraitInstanceIdValidator(validator.VisitorValidator):
                           component.instance_id))
       instances.add(component.instance_id)
 
-    for trait_type, instances in trait_types.iteritems():
-      if 0 not in instances:
-        self.add_failure("Trait type %s does not have a "
-                         "component with instance id 0." %
-                         (trait_type.full_name))
-
-
 process = TraitInstanceIdValidator.process


### PR DESCRIPTION
This fixes the instance ID validator to permit instance IDs for traits
in resources to start at a number other than 0.

Caononically, a trait instance is usually numbered from 0 - however in
cases where there are derived traits involved, while each of the derived
traits may be different in trait, given they share the same base trait,
they each have to have a different instance ID to permit polymorphic
access to those base traits.

E.g Trait A is extended by B and C (i.e B->A, C->A).

When instantiating both B and C in a resource, they each have to have
different instance IDs.

This allows a down-casting of each to of type A and be accessed
independently.