### PR TITLE
Add a test event to exercise a codepath in generated code.

### DIFF
--- a/codegen/weave-device-cpp/reference/nest/test/trait/TestETrait.cpp
+++ b/codegen/weave-device-cpp/reference/nest/test/trait/TestETrait.cpp
@@ -258,6 +258,66 @@ const nl::Weave::Profiles::DataManagement::EventSchema TestEEmptyEvent::Schema =
     .mMinCompatibleDataSchemaVersion = 1,
 };
 
+const nl::FieldDescriptor TestELargeArrayNullableEventFieldDescriptors[] =
+{
+    {
+        NULL, offsetof(TestELargeArrayNullableEvent, telaneA), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeUInt32, 1), 1
+    },
+
+    {
+        NULL, offsetof(TestELargeArrayNullableEvent, telaneB) + offsetof(Schema::Nest::Test::Trait::TestETrait::StructELarge_array, num), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeArray, 0), 2
+    },
+    {
+        &Schema::Nest::Test::Trait::TestETrait::StructELarge::FieldSchema, offsetof(TestELargeArrayNullableEvent, telaneB) + offsetof(Schema::Nest::Test::Trait::TestETrait::StructELarge_array, buf), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeStructure, 0), 2
+    },
+
+};
+
+const nl::SchemaFieldDescriptor TestELargeArrayNullableEvent::FieldSchema =
+{
+    .mNumFieldDescriptorElements = sizeof(TestELargeArrayNullableEventFieldDescriptors)/sizeof(TestELargeArrayNullableEventFieldDescriptors[0]),
+    .mFields = TestELargeArrayNullableEventFieldDescriptors,
+    .mSize = sizeof(TestELargeArrayNullableEvent)
+};
+const nl::Weave::Profiles::DataManagement::EventSchema TestELargeArrayNullableEvent::Schema =
+{
+    .mProfileId = kWeaveProfileId,
+    .mStructureType = 0x4,
+    .mImportance = nl::Weave::Profiles::DataManagement::Production,
+    .mDataSchemaVersion = 2,
+    .mMinCompatibleDataSchemaVersion = 1,
+};
+
+const nl::FieldDescriptor TestESmallArrayNullableEventFieldDescriptors[] =
+{
+    {
+        NULL, offsetof(TestESmallArrayNullableEvent, tesaneA), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeUInt32, 1), 1
+    },
+
+    {
+        NULL, offsetof(TestESmallArrayNullableEvent, tesaneB) + offsetof(nl::SerializedFieldTypeBoolean_array, num), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeArray, 0), 2
+    },
+    {
+        NULL, offsetof(TestESmallArrayNullableEvent, tesaneB) + offsetof(nl::SerializedFieldTypeBoolean_array, buf), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeBoolean, 0), 2
+    },
+
+};
+
+const nl::SchemaFieldDescriptor TestESmallArrayNullableEvent::FieldSchema =
+{
+    .mNumFieldDescriptorElements = sizeof(TestESmallArrayNullableEventFieldDescriptors)/sizeof(TestESmallArrayNullableEventFieldDescriptors[0]),
+    .mFields = TestESmallArrayNullableEventFieldDescriptors,
+    .mSize = sizeof(TestESmallArrayNullableEvent)
+};
+const nl::Weave::Profiles::DataManagement::EventSchema TestESmallArrayNullableEvent::Schema =
+{
+    .mProfileId = kWeaveProfileId,
+    .mStructureType = 0x5,
+    .mImportance = nl::Weave::Profiles::DataManagement::Production,
+    .mDataSchemaVersion = 2,
+    .mMinCompatibleDataSchemaVersion = 1,
+};
+
 //
 // Event Structs
 //
@@ -303,6 +363,42 @@ const nl::SchemaFieldDescriptor NullableE::FieldSchema =
     .mNumFieldDescriptorElements = sizeof(NullableEFieldDescriptors)/sizeof(NullableEFieldDescriptors[0]),
     .mFields = NullableEFieldDescriptors,
     .mSize = sizeof(NullableE)
+};
+
+
+const nl::FieldDescriptor StructELargeFieldDescriptors[] =
+{
+    {
+        NULL, offsetof(StructELarge, selA), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeUInt32, 0), 1
+    },
+
+    {
+        NULL, offsetof(StructELarge, selB), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeUInt32, 0), 2
+    },
+
+    {
+        NULL, offsetof(StructELarge, selC), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeUInt32, 0), 3
+    },
+
+    {
+        NULL, offsetof(StructELarge, selD), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeUInt32, 0), 4
+    },
+
+    {
+        NULL, offsetof(StructELarge, selF), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeUInt32, 0), 5
+    },
+
+    {
+        NULL, offsetof(StructELarge, selG), SET_TYPE_AND_FLAGS(nl::SerializedFieldTypeBoolean, 0), 6
+    },
+
+};
+
+const nl::SchemaFieldDescriptor StructELarge::FieldSchema =
+{
+    .mNumFieldDescriptorElements = sizeof(StructELargeFieldDescriptors)/sizeof(StructELargeFieldDescriptors[0]),
+    .mFields = StructELargeFieldDescriptors,
+    .mSize = sizeof(StructELarge)
 };
 
 } // namespace TestETrait

--- a/codegen/weave-device-cpp/reference/nest/test/trait/TestETrait.h
+++ b/codegen/weave-device-cpp/reference/nest/test/trait/TestETrait.h
@@ -121,6 +121,24 @@ inline bool NullableE::IsNeBPresent(void)
     return (!GET_FIELD_NULLIFIED_BIT(__nullified_fields__, 1));
 }
 #endif
+struct StructELarge
+{
+    uint32_t selA;
+    uint32_t selB;
+    uint32_t selC;
+    uint32_t selD;
+    uint32_t selF;
+    bool selG;
+
+    static const nl::SchemaFieldDescriptor FieldSchema;
+
+};
+
+struct StructELarge_array {
+    uint32_t num;
+    StructELarge *buf;
+};
+
 //
 // Events
 //
@@ -530,6 +548,94 @@ struct TestEEmptyEvent_array {
     TestEEmptyEvent *buf;
 };
 
+
+struct TestELargeArrayNullableEvent
+{
+    uint32_t telaneA;
+    void SetTelaneANull(void);
+    void SetTelaneAPresent(void);
+#if WEAVE_CONFIG_SERIALIZATION_ENABLE_DESERIALIZATION
+    bool IsTelaneAPresent(void);
+#endif
+    Schema::Nest::Test::Trait::TestETrait::StructELarge_array telaneB;
+    uint8_t __nullified_fields__[1/8 + 1];
+
+    static const nl::SchemaFieldDescriptor FieldSchema;
+
+    // Statically-known Event Struct Attributes:
+    enum {
+            kWeaveProfileId = (0x235aU << 16) | 0xfe06U,
+        kEventTypeId = 0x4U
+    };
+
+    static const nl::Weave::Profiles::DataManagement::EventSchema Schema;
+};
+
+struct TestELargeArrayNullableEvent_array {
+    uint32_t num;
+    TestELargeArrayNullableEvent *buf;
+};
+
+inline void TestELargeArrayNullableEvent::SetTelaneANull(void)
+{
+    SET_FIELD_NULLIFIED_BIT(__nullified_fields__, 0);
+}
+
+inline void TestELargeArrayNullableEvent::SetTelaneAPresent(void)
+{
+    CLEAR_FIELD_NULLIFIED_BIT(__nullified_fields__, 0);
+}
+
+#if WEAVE_CONFIG_SERIALIZATION_ENABLE_DESERIALIZATION
+inline bool TestELargeArrayNullableEvent::IsTelaneAPresent(void)
+{
+    return (!GET_FIELD_NULLIFIED_BIT(__nullified_fields__, 0));
+}
+#endif
+
+struct TestESmallArrayNullableEvent
+{
+    uint32_t tesaneA;
+    void SetTesaneANull(void);
+    void SetTesaneAPresent(void);
+#if WEAVE_CONFIG_SERIALIZATION_ENABLE_DESERIALIZATION
+    bool IsTesaneAPresent(void);
+#endif
+    nl::SerializedFieldTypeBoolean_array  tesaneB;
+    uint8_t __nullified_fields__[1/8 + 1];
+
+    static const nl::SchemaFieldDescriptor FieldSchema;
+
+    // Statically-known Event Struct Attributes:
+    enum {
+            kWeaveProfileId = (0x235aU << 16) | 0xfe06U,
+        kEventTypeId = 0x5U
+    };
+
+    static const nl::Weave::Profiles::DataManagement::EventSchema Schema;
+};
+
+struct TestESmallArrayNullableEvent_array {
+    uint32_t num;
+    TestESmallArrayNullableEvent *buf;
+};
+
+inline void TestESmallArrayNullableEvent::SetTesaneANull(void)
+{
+    SET_FIELD_NULLIFIED_BIT(__nullified_fields__, 0);
+}
+
+inline void TestESmallArrayNullableEvent::SetTesaneAPresent(void)
+{
+    CLEAR_FIELD_NULLIFIED_BIT(__nullified_fields__, 0);
+}
+
+#if WEAVE_CONFIG_SERIALIZATION_ENABLE_DESERIALIZATION
+inline bool TestESmallArrayNullableEvent::IsTesaneAPresent(void)
+{
+    return (!GET_FIELD_NULLIFIED_BIT(__nullified_fields__, 0));
+}
+#endif
 
 //
 // Enums

--- a/test/schema/nest/test/trait/test_e_trait.proto
+++ b/test/schema/nest/test/trait/test_e_trait.proto
@@ -159,4 +159,45 @@ message TestETrait {
             reserved_tag_max: 31
         };
     }
+
+    message StructELarge {
+        option (wdl.message_type) = STRUCT;
+        option (wdl.structopts) = {
+            extendable: true,
+            reserved_tag_min: 1,
+            reserved_tag_max: 31
+        };
+
+        uint32 sel_a = 1;
+        uint32 sel_b = 2;
+        uint32 sel_c = 3;
+        uint32 sel_d = 4;
+        uint32 sel_f = 5;
+        bool sel_g = 6;
+    }
+
+    message TestELargeArrayNullableEvent {
+        option (wdl.message_type) = EVENT;
+        option (wdl.event) = {
+            id: 4,
+            event_importance: EVENT_IMPORTANCE_PRODUCTION_STANDARD,
+            extendable: true,
+            reserved_tag_min: 1,
+            reserved_tag_max: 31
+        };
+        google.protobuf.UInt32Value telane_a = 1 [(wdl.param) = {nullable: true}];
+        repeated StructELarge telane_b = 2;
+    }
+    message TestESmallArrayNullableEvent {
+        option (wdl.message_type) = EVENT;
+        option (wdl.event) = {
+            id: 5,
+            event_importance: EVENT_IMPORTANCE_PRODUCTION_STANDARD,
+            extendable: true,
+            reserved_tag_min: 1,
+            reserved_tag_max: 31
+        };
+        google.protobuf.UInt32Value tesane_a = 1 [(wdl.param) = {nullable: true}];
+        repeated bool tesane_b = 2;
+    }
 }


### PR DESCRIPTION
Generated C++ code contained an issue where the behavior of nullified
fields was incorrect when the last field in a structure was an array.
Add sample events to drive the test behavior.