### PR TITLE
Pin protobuf version to last working version

### DIFF
--- a/backend/pip-install-requirements.txt
+++ b/backend/pip-install-requirements.txt
@@ -1,4 +1,4 @@
 enum34==1.1.6
-protobuf>=3.5.2
+protobuf==3.17.3
 inflection==0.3.1
 Jinja2>=2.10.1


### PR DESCRIPTION
The README indicates that protobuf must be in 3.5.1 to 3.7.1, but it has continued to work with newer versions up until 3.18.0 released 2021/09/15.
Fix the build by pinning the protobuf version to the last compatible version, 3.17.3.